### PR TITLE
Admin update status order, admin and user destroy order

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -79,6 +79,13 @@
   .nav-link {
     border-bottom: none !important;
   }
+  .dropdown-menu {
+    left: -50px;
+  }
+  .dropdown-item {
+    display: block;
+    padding: 0.25rem 1.5rem;
+  }
 }
 .navbar-main {
   display: flex;
@@ -132,4 +139,26 @@
 }
 .product-item:hover .product-img img {
   transform: scale(1.2);
+}
+.table {
+  text-align: center;
+}
+.badge {
+  font-size: 14px !important;
+}
+.badge-pending {
+  background-color: #cfe0fc !important;
+  color: #0a47a9 !important;
+}
+.badge-confirmed {
+  background-color: #c7f5d9 !important;
+  color: #0b4121 !important;
+}
+.badge-delivering {
+  background-color: #ffebc2 !important;
+  color: #453008 !important;
+}
+.badge-received {
+  background-color: #f0d8ff !important;
+  color: #453008 !important;
 }

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,0 +1,27 @@
+class Admin::OrdersController < AdminController
+  before_action :find_order, only: %i(destroy update)
+  before_action :update_quantity, only: :destroy
+
+  def index
+    @delivering_orders = Order.delivering
+    @received_orders = Order.received
+    @pending_orders = Order.pending
+    @pagy, @orders = pagy(Order.newest, items: Settings.pagy_item_10)
+  end
+
+  def destroy
+    redirect_to admin_orders_path
+  end
+
+  def update
+    return if params[:order].nil?
+
+    flash[:danger] = t "global.danger.not_order"
+    if @order.update status: params[:order][:status]
+      flash[:success] = t "global.success.update_status_order"
+    else
+      flash[:danger] = t "global.danger.update_status_order"
+    end
+    redirect_to admin_orders_path
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   include SessionsHelper
   include CartsHelper
+  include OrdersHelper
   include Pagy::Backend
   rescue_from Pagy::OverflowError, with: :redirect_to_last_page
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -3,8 +3,12 @@ class OrdersController < ApplicationController
   before_action :build_order, only: %i(new create)
   before_action :total_price_into_cart,
                 :build_order_detail, only: :create
+  before_action :load_orders, only: :index
+  before_action :find_order, :update_quantity, only: :destroy
 
   def new; end
+
+  def index; end
 
   def create
     @order.subtotal = @sum
@@ -17,6 +21,10 @@ class OrdersController < ApplicationController
   rescue ActiveRecord::RecordNotSaved
     flash[:danger] = t "global.danger.order"
     render :new
+  end
+
+  def destroy
+    redirect_to orders_path
   end
 
   private
@@ -37,5 +45,13 @@ class OrdersController < ApplicationController
       @order.order_details.build(product_id: product_id, quantity: quantity,
         price: price)
     end
+  end
+
+  def load_orders
+    @orders = current_user.orders.newest
+    return if @orders
+
+    flash[:danger] = t ".not_found"
+    redirect_to root_path
   end
 end

--- a/app/helpers/admin/orders/orders_helper.rb
+++ b/app/helpers/admin/orders/orders_helper.rb
@@ -1,0 +1,10 @@
+module Admin::Orders::OrdersHelper
+  def contain_status order
+    array_status = []
+    t("order_status").to_a.each{|status| array_status.push(status.reverse)}
+    @arr_status = array_status if order.pending?
+    @arr_status = array_status.drop 1 if order.confirmed?
+    @arr_status = array_status.drop 2 if order.delivering?
+    @arr_status = array_status.drop 3 if order.received?
+  end
+end

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -1,0 +1,29 @@
+module OrdersHelper
+  def find_order
+    @order = Order.find_by id: params[:id]
+    return if @order
+
+    flash[:danger] = t ".not_found"
+    redirect_to root_path
+  end
+
+  def update_quantity
+    if @order.pending?
+      begin
+        ActiveRecord::Base.transaction do
+          @order.deleted!
+          @order.order_details.each do |order_detail|
+            stock = order_detail.product.stock
+            stock += order_detail.quantity
+            order_detail.product.update! stock: stock
+          end
+        end
+      rescue ActiveRecord::RecordNotSaved
+        flash[:danger] = t "global.danger.destroy_danger"
+      end
+      flash[:success] = t "global.success.destroy_success"
+    else
+      flash[:danger] = t "global.danger.pending_deleted"
+    end
+  end
+end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -5,4 +5,9 @@ class Order < ApplicationRecord
   validates :name, presence: true
   validates :phone, presence: true
   validates :address, presence: true
+
+  enum status: {pending: 0, confirmed: 1, delivering: 2, received: 3,
+                deleted: 4}
+
+  scope :newest, ->{order created_at: :desc}
 end

--- a/app/views/admin/_admin_nav.html.erb
+++ b/app/views/admin/_admin_nav.html.erb
@@ -54,7 +54,7 @@
       </div>
     </li>
     <li class="nav-item">
-      <%= link_to raw(t "menu.admin.order_manage"), "#", class: "nav-link" %>
+      <%= link_to raw(t "menu.admin.order_manage"), admin_orders_path, class: "nav-link" %>
     </li>
   </ul>
 </nav>

--- a/app/views/admin/orders/_order.html.erb
+++ b/app/views/admin/orders/_order.html.erb
@@ -1,0 +1,25 @@
+<tr>
+  <%= form_for :order, url: admin_order_path(order.id), method: :patch do |f| %>
+  <th>#<%= order.id %></th>
+  <td><%= order.created_at.strftime(Settings.format_time) %></td>
+  <td><%= number_to_currency order.subtotal %></td>
+  <td>
+    <% if order.deleted? %>
+      <span class="badge rounded-pill d-inline" %><%= t ".deleted" %></span>
+    <% else %>
+      <% contain_status order %>
+      <%= f.select(:status, options_for_select(@arr_status, order.status)) %>
+    <% end %>
+  </td>
+  <td><%= order.name %></td>
+  <td><%= order.phone %></td>
+  <td><%= order.address %></td>
+  <td>
+    <%= link_to t("global.button.view"), "#", class: "btn btn-primary" %>
+    <% unless order.deleted? %>
+      <%= f.submit t("global.button.update"), class: "btn btn-success" %>
+      <%= link_to t("global.button.delete"), admin_order_path(order.id), method: :delete, data: {confirm: t("global.confirm.delete")}, remote: true, class: "btn btn-warning" %>
+    <% end %>
+  </td>
+  <% end %>
+</tr>

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -1,0 +1,36 @@
+<div class="main-panel">
+  <div class="content-wrapper">
+    <div class="row">
+      <div class="col-lg-12 grid-margin stretch-card">
+        <div class="card">
+          <div class="card-body">
+            <h4 class="card-title"><%= t "page.admin.list_products_title"%></h4>
+            <h4 class="card-title"><%= t "order_status.received"%>: <%= @received_orders.count %></h4>
+            <h4 class="card-title"><%= t "order_status.pending"%>: <%= @pending_orders.count %></h4>
+            <h4 class="card-title"><%= t "order_status.delivering"%>: <%= @delivering_orders.count %></h4>
+            <div class="table-responsive">
+              <table class="table table-striped">
+                <thead>
+                  <tr>
+                    <th><%= t "page.order.order_id"%></th>
+                    <th><%= t "page.order.date"%></th>
+                    <th><%= t "page.order.subtotal"%></th>
+                    <th><%= t "page.order.status"%></th>
+                    <th><%= t "page.order.by_user"%></th>
+                    <th><%= t "page.order.phone"%></th>
+                    <th><%= t "page.order.address"%></th>
+                    <th><%= t "global.operation"%></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <%= render @orders %>
+                </tbody>
+              </table>
+              <%== pagy_nav(@pagy)%>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/orders/_order_row.html.erb
+++ b/app/views/orders/_order_row.html.erb
@@ -1,0 +1,13 @@
+<tr>
+  <th scope="row">#<%= order.id %></th>
+  <td><%= order.created_at.strftime("%F | %T") %></td>
+  <td><%= number_to_currency order.subtotal %></td>
+  <td>
+    <span class='<%= "badge badge-#{order.status} rounded-pill d-inline" %>'><%= t "order_status.#{order.status}" %></span>
+  </td>
+  <td>
+    <div class="d-flex gap-2 d-md-block" style="justify-content: center;">
+      <%= button_to t("global.button.delete"), order_path(order.id), class: "btn btn-primary", method: :delete, data: {confirm: t("global.confirm.delete")}, remote: true %>
+    </div>
+  </td>
+</tr>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,0 +1,14 @@
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col"><%= t "page.order.order_id" %></th>
+      <th scope="col"><%= t "page.order.date" %></th>
+      <th scope="col"><%= t "page.order.subtotal" %></th>
+      <th scope="col"><%= t "page.order.status" %></th>
+      <th scope="col"><%= t "page.order.operation" %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <%= render partial: "order_row", collection: @orders, as: :order %>
+  </tbody>
+</table>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,12 @@ en:
         delimiter: ","
         unit: "$"
 
+  order_status:
+    pending: "Pending"
+    confirmed: "Confirmed"
+    delivering: "Delivering"
+    received: "Received"
+
   global:
     base_title: "E-commerce website"
     footer_text: "Project 1: Vo Trong Thanh | Sun VN"
@@ -45,12 +51,20 @@ en:
       log_in: "Please login"
       delivery_info: "Please enter your delivery information"
       order: "Order failed"
+      update_status_order: "Update order status failed"
+      destroy_danger: "Destroy order failed"
+      pending_deleted: "Only orders pending for confirmation can be deleted"
+      not_order: "Order does not exist"
     success:
       log_in: "Login successfully"
       add_cart: "Product added to cart successfully"
       remove_product_from_cart: "Remove product from cart successfully"
       update_cart: "Update quantity successfully"
       order: "Order Success"
+      category_not_found: "Category not found"
+      update_status_order: "Update order status successfully"
+      log_in: "Log in successfully"
+      destroy_success: "Deleted order successfully"
     button:
       view: "View"
       edit: "Edit"
@@ -94,6 +108,7 @@ en:
       title: "Admin Dashboard"
       sub_title: "E-commerce website management system."
       list_products_title: "Products list"
+      order_detail: "Order details "
     home:
       list_products: "List Products"
       view_detail: "View Detail"
@@ -113,3 +128,16 @@ en:
       products: "Products"
       total: "Total"
       place_order: "Place Order"
+      order_id: "Order ID"
+      date: "Order date"
+      subtotal: "Subtotal"
+      status: "Status"
+      by_user: "Customer"
+      phone: "Phone"
+      address: "Address"
+      operation: "Operation"
+  admin:
+    orders:
+      not_found: "Order not found"
+      order:
+        deleted: "Deleted"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -36,6 +36,12 @@ vi:
         strip_insignificant_zeros: false
         unit: "đồng"
 
+  order_status:
+    pending: "Chờ xác nhận"
+    confirmed: "Đã xác nhận"
+    delivering: "Đang giao"
+    received: "Đã nhận"
+
   global:
     base_title: "Website thương mại điện tử"
     footer_text: "Project 1: Võ Trọng Thanh | Sun VN"
@@ -47,12 +53,20 @@ vi:
       log_in: "Xin hãy đăng nhập"
       delivery_info: "Vui lòng nhập thông tin nhận hàng"
       order: "Đặt hàng thất bại"
+      update_status_order: "Cập nhật trạng thái đơn hàng thất bại"
+      destroy_danger: "Hủy đơn hàng thất bại"
+      pending_deleted: "Chỉ được xóa đơn hàng chờ xác nhận"
+      not_order: "Không tồn tại đơn hàng"
     success:
       log_in: "Đăng nhập thành công"
       add_cart: "Thêm sản phẩm vào giỏ hàng thành công"
       remove_product_from_cart: "Xóa sản phẩm khỏi giỏ hàng thành công"
       update_cart: "Cập nhật số lượng thành công"
       order: "Đặt hàng thành công"
+      category_not_found: "Không tìm thấy danh mục"
+      update_status_order: "Cập nhật trạng thái đơn hàng thành công"
+      log_in: "Đăng nhập thành công"
+      destroy_success: "Hủy đơn hàng thành công"
     button:
       view: "Xem"
       edit: "Sửa"
@@ -96,6 +110,7 @@ vi:
       title: "Trang quản trị"
       sub_title: "Hệ thống quản lý website thương mại điện tử."
       list_products_title: "Danh sách sản phẩm"
+      order_detail: "Chi tiết đơn hàng "
     home:
       list_products: "Danh sách sản phẩm"
       view_detail: "Xem chi tiết"
@@ -115,3 +130,16 @@ vi:
       products: "Sản phẩm"
       total: "Tổng tiền"
       place_order: "Đặt hàng"
+      order_id: "Mã đơn hàng"
+      date: "Ngày đặt hàng"
+      subtotal: "Tổng tiền"
+      status: "Trạng thái đơn hàng"
+      by_user: "Khách hàng"
+      phone: "Điện thoại"
+      address: "Địa chỉ"
+      operation: "Thao tác"
+  admin:
+    orders:
+      not_found: "Không tìm thấy đơn hàng"
+      order:
+        deleted: "Đã hủy"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,12 +6,15 @@ Rails.application.routes.draw do
     delete "/logout", to: "sessions#destroy"
 
     resource :carts
-
-    resource :orders
+    resources :orders
+    resources :categories do
+      get "/products", to: "home#index"
+    end
 
     namespace :admin do
       get "index"
 
+      resources :orders
       resources :products, only: %i(index update create destroy)
     end
   end

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,3 +1,5 @@
 length_8: 8
 length_20: 20
 pagy_item_8: 8
+pagy_item_10: 10
+format_time: "%F | %T"


### PR DESCRIPTION
## Related Tickets
- [#48604 - Thanh](https://edu-redmine.sun-asterisk.vn/issues/48604)

## WHAT (optional)
- Admin change status order
- Admin and user destroy order

## HOW
- Use enum to save status order
- Use options_for_select field status
## WHY (optional)

## Evidence (Screenshot or Video)

![Screenshot from 2022-05-06 15-50-57](https://user-images.githubusercontent.com/102727895/167102318-09a6f4cf-4369-432e-bba0-154befd815b9.png)

![Screenshot from 2022-05-06 15-50-24](https://user-images.githubusercontent.com/102727895/167102330-b3318c62-a86f-453a-87d2-0b42334db3ef.png)

![Screenshot from 2022-05-06 15-49-48](https://user-images.githubusercontent.com/102727895/167102336-6a6e82fa-1ac5-447f-9586-dd8cf359a185.png)
